### PR TITLE
Turn private AirplaneModeChecker constructor.

### DIFF
--- a/lib/airplane_mode_checker.dart
+++ b/lib/airplane_mode_checker.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 enum AirplaneModeStatus { on, off }
 
 class AirplaneModeChecker {
+  AirplaneModeChecker._();
   static const MethodChannel _channel = MethodChannel('airplane_mode_checker');
 
   static Future<String?> get platformVersion async {


### PR DESCRIPTION
That all methods is static, make sense omit the constructor for a better legibility.