### PR TITLE
Add Swift Package Manager support and prepare 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,67 +1,29 @@
-## 0.0.1
-
-- Flutter plugin for check airplane mode
-
-## 1.0.0
-
-- Publishing plugin
-
-## 1.0.1
-
-- Update SwiftAirplaneModeCheckerPlugin.swift
-
-## 1.0.2
-
-- Update readme
-
-## 1.0.3
-
-- Update readme
-
-## 1.0.4
-
-- Turn private AirplaneModeChecker constructor (PR https://github.com/14h4i/airplane_mode_checker/pull/6)
-
-## 1.0.5
-
-- Remove print on iOS and clean up native code (PR https://github.com/14h4i/airplane_mode_checker/pull/8)
-  Thanks @stefanschaller
-
-## 2.0.0
+## 3.3.0
 
 **Updates:**
 
-- Android Gradle plugin (AGP)
-- Gradle wrapper
-- Kotlin version
-- compileSdkVersion
-- Update dependencies
+- **iOS / Swift Package Manager:**
+  - Added Swift Package Manager support for the iOS plugin
+  - Moved iOS sources to the Swift Package Manager layout
+  - Added Swift Package Manager support for iOS 12.0 and higher
+  - Preserved CocoaPods support for iOS 12.0 and higher
 
-## 2.1.0
+- **Documentation and examples:**
+  - Clarified best-effort iOS stream behavior for `listenAirplaneMode()`
+  - Fixed README usage examples to match the actual singleton API
+  - Updated the example README and fixed stale example widget tests
 
-**Updates:**
+- **Tests and maintenance:**
+  - Added more Dart tests for `OFF`, `null`, and stream mapping cases
+  - Improved Android stream lifecycle cleanup
+  - Removed unused iOS implementation pieces
 
-- Logic check airplane for IOS
-- Issue (https://github.com/14h4i/airplane_mode_checker/issues/11)
-
-## 2.2.0
-
-**Updates:**
-
-- Moved dependency 'fluttertoast' to example folder (https://github.com/14h4i/airplane_mode_checker/pull/14)
-
-## 3.0.0
+## 3.2.1
 
 **Updates:**
 
-- Migrate to new base
-- Add `namespace` - Support for AGP Version (https://github.com/14h4i/airplane_mode_checker/issues/15)
-
-## 3.1.0
-
-**Updates:**
-
-- New feature `AirplaneModeChecker.instance.listenAirplaneMode()` for request (https://github.com/14h4i/airplane_mode_checker/issues/16)
+- Add optional `defaultValue` to `checkAirplaneMode` and `listenAirplaneMode`
+  for WiFi-only iOS devices.
 
 ## 3.2.0
 
@@ -87,9 +49,67 @@
   - Improved code quality and documentation
   - Updated podspec with proper metadata
 
-## 3.2.1
+## 3.1.0
 
 **Updates:**
 
-- Add optional `defaultValue` to `checkAirplaneMode` and `listenAirplaneMode`
-  for WiFi-only iOS devices.
+- New feature `AirplaneModeChecker.instance.listenAirplaneMode()` for request (https://github.com/14h4i/airplane_mode_checker/issues/16)
+
+## 3.0.0
+
+**Updates:**
+
+- Migrate to new base
+- Add `namespace` - Support for AGP Version (https://github.com/14h4i/airplane_mode_checker/issues/15)
+
+## 2.2.0
+
+**Updates:**
+
+- Moved dependency 'fluttertoast' to example folder (https://github.com/14h4i/airplane_mode_checker/pull/14)
+
+## 2.1.0
+
+**Updates:**
+
+- Logic check airplane for IOS
+- Issue (https://github.com/14h4i/airplane_mode_checker/issues/11)
+
+## 2.0.0
+
+**Updates:**
+
+- Android Gradle plugin (AGP)
+- Gradle wrapper
+- Kotlin version
+- compileSdkVersion
+- Update dependencies
+
+## 1.0.5
+
+- Remove print on iOS and clean up native code (PR https://github.com/14h4i/airplane_mode_checker/pull/8)
+  Thanks @stefanschaller
+
+## 1.0.4
+
+- Turn private AirplaneModeChecker constructor (PR https://github.com/14h4i/airplane_mode_checker/pull/6)
+
+## 1.0.3
+
+- Update readme
+
+## 1.0.2
+
+- Update readme
+
+## 1.0.1
+
+- Update SwiftAirplaneModeCheckerPlugin.swift
+
+## 1.0.0
+
+- Publishing plugin
+
+## 0.0.1
+
+- Flutter plugin for check airplane mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 3.3.0
+
+**Updates:**
+
+- **iOS / Swift Package Manager:**
+  - Added Swift Package Manager support for the iOS plugin
+  - Moved iOS sources to the Swift Package Manager layout
+  - Updated minimum iOS version to 13.0
+
+- **Documentation and examples:**
+  - Clarified iOS polling behavior for `listenAirplaneMode()`
+  - Fixed README usage examples to match the actual singleton API
+  - Updated the example README and fixed stale example widget tests
+
+- **Tests and maintenance:**
+  - Added more Dart tests for `OFF`, `null`, and stream mapping cases
+  - Improved Android stream lifecycle cleanup
+  - Removed unused iOS implementation pieces
+
 ## 0.0.1
 
 - Flutter plugin for check airplane mode

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Flutter plugin allows you to check the status of Airplane Mode on iOS and Andr
 - ✅ Works on **cellular devices** (iPhone, iPad with cellular)
 - ❌ **Limited accuracy** on WiFi-only devices (iPad WiFi, iPod Touch)
 - The plugin uses `CTTelephonyNetworkInfo` which only works with cellular radios
+- Stream updates on iOS are best-effort due to platform limitations
 
 This is a platform limitation by Apple, not a plugin issue. The plugin provides the best detection possible within iOS constraints.
 
@@ -33,7 +34,7 @@ Add the following line to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  airplane_mode_checker: ^3.2.0
+  airplane_mode_checker: ^3.3.0
 ```
 
 Add the following import to your Dart code:
@@ -42,9 +43,12 @@ Add the following import to your Dart code:
 import 'package:airplane_mode_checker/airplane_mode_checker.dart';
 ```
 
+On iOS, this plugin supports both the traditional CocoaPods flow and Flutter's Swift Package Manager integration.
+Flutter's Swift Package Manager integration requires Flutter 3.24 or higher in the consuming app.
+
 ### Check Airplane Mode
 
-In order to check the airplane mode, use `AirplaneModeChecker.checkAirplaneMode()` as below.
+In order to check the airplane mode, use `AirplaneModeChecker.instance.checkAirplaneMode()` as below.
 
 You will get the return `AirplaneModeStatus`:
 
@@ -66,6 +70,9 @@ To listen for changes in the status of airplane mode, use `AirplaneModeChecker.i
 
 This will return a `Stream<AirplaneModeStatus>`:
 
+- Android: emits the initial status and listens for system airplane mode changes
+- iOS: emits the initial status and then polls every second
+
 ```dart
 AirplaneModeChecker.instance.listenAirplaneMode().listen((status) {
   if (status == AirplaneModeStatus.on) {
@@ -78,17 +85,17 @@ AirplaneModeChecker.instance.listenAirplaneMode().listen((status) {
 
 ## Requirements
 
-- **iOS**: 12.0 or higher
+- **iOS**: 13.0 or higher
 - **Android**: API 16 (Jelly Bean) or higher
 - **Flutter**: 3.3.0 or higher
 - **Dart**: 3.3.0 or higher
 
 ## iOS available
 
-iOS is available from version 12
+iOS is available from version 13
 
 ```swift
-@available(iOS 12.0, *)
+@available(iOS 13.0, *)
 ```
 
 ## ScreenShots

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A Flutter plugin allows you to check the status of Airplane Mode on iOS and Andr
 - The plugin uses `CTTelephonyNetworkInfo` which only works with cellular radios
 - WiFi-only iOS devices return `AirplaneModeStatus.off` by default, but callers
   can override this with `defaultValue`
+- Stream updates on iOS are best-effort due to platform limitations
 
 This is a platform limitation by Apple, not a plugin issue. The plugin provides the best detection possible within iOS constraints.
 
@@ -35,7 +36,7 @@ Add the following line to `pubspec.yaml`:
 
 ```yaml
 dependencies:
-  airplane_mode_checker: ^3.2.1
+  airplane_mode_checker: ^3.3.0
 ```
 
 Add the following import to your Dart code:
@@ -44,9 +45,13 @@ Add the following import to your Dart code:
 import 'package:airplane_mode_checker/airplane_mode_checker.dart';
 ```
 
+On iOS, this plugin supports both the traditional CocoaPods flow and Flutter's Swift Package Manager integration.
+Both integration methods support iOS 12.0 or higher.
+Using Swift Package Manager integration in the consuming app requires Flutter 3.24 or higher.
+
 ### Check Airplane Mode
 
-In order to check the airplane mode, use `AirplaneModeChecker.checkAirplaneMode()` as below.
+In order to check the airplane mode, use `AirplaneModeChecker.instance.checkAirplaneMode()` as below.
 
 You will get the return `AirplaneModeStatus`:
 
@@ -77,6 +82,9 @@ To listen for changes in the status of airplane mode, use `AirplaneModeChecker.i
 
 This will return a `Stream<AirplaneModeStatus>`:
 
+- Android: emits the initial status and listens for system airplane mode changes
+- iOS: emits best-effort updates due to platform limitations
+
 ```dart
 AirplaneModeChecker.instance.listenAirplaneMode().listen((status) {
   if (status == AirplaneModeStatus.on) {
@@ -104,7 +112,7 @@ AirplaneModeChecker.instance.listenAirplaneMode(
 
 ## iOS available
 
-iOS is available from version 12
+iOS is available from version 12 with CocoaPods and Swift Package Manager.
 
 ```swift
 @available(iOS 12.0, *)

--- a/android/src/main/kotlin/com/u14h4i/airplane_mode_checker/AirplaneModeCheckerPlugin.kt
+++ b/android/src/main/kotlin/com/u14h4i/airplane_mode_checker/AirplaneModeCheckerPlugin.kt
@@ -20,6 +20,7 @@ class AirplaneModeCheckerPlugin: FlutterPlugin, MethodCallHandler, EventChannel.
   private lateinit var eventChannel: EventChannel
   private lateinit var context: Context
   private var eventSink: EventChannel.EventSink? = null
+  private var receiverRegistered = false
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "airplane_mode_checker")
@@ -27,9 +28,6 @@ class AirplaneModeCheckerPlugin: FlutterPlugin, MethodCallHandler, EventChannel.
     eventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "airplane_mode_checker_stream")
     eventChannel.setStreamHandler(this)
     context = flutterPluginBinding.applicationContext
-
-    // Check initial airplane mode status
-    checkInitialAirplaneMode()
   }
 
   override fun onMethodCall(@NonNull call: MethodCall, @NonNull result: Result) {
@@ -57,14 +55,20 @@ class AirplaneModeCheckerPlugin: FlutterPlugin, MethodCallHandler, EventChannel.
 
   override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
     eventSink = events
-    val filter = IntentFilter(Intent.ACTION_AIRPLANE_MODE_CHANGED)
-    context.registerReceiver(airplaneModeReceiver, filter)
+    if (!receiverRegistered) {
+      val filter = IntentFilter(Intent.ACTION_AIRPLANE_MODE_CHANGED)
+      context.registerReceiver(airplaneModeReceiver, filter)
+      receiverRegistered = true
+    }
     // Emit initial status
     checkInitialAirplaneMode()
   }
 
   override fun onCancel(arguments: Any?) {
-    context.unregisterReceiver(airplaneModeReceiver)
+    if (receiverRegistered) {
+      context.unregisterReceiver(airplaneModeReceiver)
+      receiverRegistered = false
+    }
     eventSink = null
   }
 
@@ -76,6 +80,11 @@ class AirplaneModeCheckerPlugin: FlutterPlugin, MethodCallHandler, EventChannel.
   }
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+    if (receiverRegistered) {
+      context.unregisterReceiver(airplaneModeReceiver)
+      receiverRegistered = false
+    }
+    eventSink = null
     methodChannel.setMethodCallHandler(null)
     eventChannel.setStreamHandler(null)
   }

--- a/example/README.md
+++ b/example/README.md
@@ -1,16 +1,19 @@
 # airplane_mode_checker_example
 
-Demonstrates how to use the airplane_mode_checker plugin.
+Example app for the `airplane_mode_checker` plugin.
 
-## Getting Started
+## What it shows
 
-This project is a starting point for a Flutter application.
+- One-time airplane mode checks with `checkAirplaneMode()`
+- Continuous updates with `listenAirplaneMode()`
 
-A few resources to get you started if this is your first Flutter project:
+## Run it
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+```sh
+flutter run
+```
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+The UI includes:
+
+- A button to query the current airplane mode state
+- A `StreamBuilder` that reflects the latest stream event from the plugin

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.0"
+    version: "3.3.0"
   async:
     dependency: transitive
     description:

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,23 +5,15 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:airplane_mode_checker_example/main.dart';
 
 void main() {
-  testWidgets('Verify Platform version', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('renders the example shell', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that platform version is retrieved.
-    expect(
-      find.byWidgetPredicate(
-        (Widget widget) => widget is Text &&
-                           widget.data!.startsWith('Running on:'),
-      ),
-      findsOneWidget,
-    );
+    expect(find.text('Check Airplane Mode'), findsOneWidget);
+    expect(find.text('Stream'), findsOneWidget);
   });
 }

--- a/ios/airplane_mode_checker.podspec
+++ b/ios/airplane_mode_checker.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'airplane_mode_checker'
-  s.version          = '3.2.0'
+  s.version          = '3.3.0'
   s.summary          = 'Flutter plugin to check Airplane Mode status on iOS and Android.'
   s.description      = <<-DESC
 A Flutter plugin that allows you to check the status of Airplane Mode on iOS and Android mobile devices.
@@ -14,9 +14,9 @@ Supports both one-time checks and continuous monitoring via streams.
   s.license          = { :file => '../LICENSE' }
   s.author           = { '14h4i' => 'https://github.com/14h4i' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
+  s.source_files = 'airplane_mode_checker/Sources/airplane_mode_checker/**/*'
   s.dependency 'Flutter'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/airplane_mode_checker.podspec
+++ b/ios/airplane_mode_checker.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'airplane_mode_checker'
-  s.version          = '3.2.1'
+  s.version          = '3.3.0'
   s.summary          = 'Flutter plugin to check Airplane Mode status on iOS and Android.'
   s.description      = <<-DESC
 A Flutter plugin that allows you to check the status of Airplane Mode on iOS and Android mobile devices.
@@ -14,7 +14,7 @@ Supports both one-time checks and continuous monitoring via streams.
   s.license          = { :file => '../LICENSE' }
   s.author           = { '14h4i' => 'https://github.com/14h4i' }
   s.source           = { :path => '.' }
-  s.source_files = 'Classes/**/*'
+  s.source_files = 'airplane_mode_checker/Sources/airplane_mode_checker/**/*'
   s.dependency 'Flutter'
   s.platform = :ios, '12.0'
 

--- a/ios/airplane_mode_checker/Package.swift
+++ b/ios/airplane_mode_checker/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "airplane_mode_checker",
+    platforms: [
+        .iOS("12.0")
+    ],
+    products: [
+        .library(name: "airplane-mode-checker", targets: ["airplane_mode_checker"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "airplane_mode_checker",
+            dependencies: [],
+            resources: []
+        )
+    ]
+)

--- a/ios/airplane_mode_checker/Package.swift
+++ b/ios/airplane_mode_checker/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version: 5.9
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "airplane_mode_checker",
+    platforms: [
+        .iOS("13.0")
+    ],
+    products: [
+        .library(name: "airplane-mode-checker", targets: ["airplane_mode_checker"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "airplane_mode_checker",
+            dependencies: [],
+            resources: []
+        )
+    ]
+)

--- a/ios/airplane_mode_checker/Sources/airplane_mode_checker/AirplaneModeCheckerPlugin.swift
+++ b/ios/airplane_mode_checker/Sources/airplane_mode_checker/AirplaneModeCheckerPlugin.swift
@@ -1,14 +1,11 @@
+import CoreTelephony
 import Flutter
 import UIKit
-import CoreTelephony
-import Network
 
 public class AirplaneModeCheckerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   private var eventSink: FlutterEventSink?
   private var timer: Timer?
-  private var pathMonitor: NWPathMonitor?
   private var streamDefaultValue = false
-  private let monitorQueue = DispatchQueue(label: "com.u14h4i.airplane_mode_checker.monitor")
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let methodChannel = FlutterMethodChannel(name: "airplane_mode_checker", binaryMessenger: registrar.messenger())
@@ -31,61 +28,49 @@ public class AirplaneModeCheckerPlugin: NSObject, FlutterPlugin, FlutterStreamHa
       result(FlutterMethodNotImplemented)
     }
   }
-    
+
   func checkAirplaneMode(defaultValue: Bool, completion: @escaping (String) -> Void) {
     let msg = self.isAirplaneModeOn(defaultValue: defaultValue) ? "ON" : "OFF"
     completion(msg)
   }
 
   func isAirplaneModeOn(defaultValue: Bool) -> Bool {
-    // Check using CTTelephonyNetworkInfo for cellular radio
     let networkInfo = CTTelephonyNetworkInfo()
-    
-    // For devices with cellular capability
+
     if let carriers = networkInfo.serviceSubscriberCellularProviders, !carriers.isEmpty {
-      // If we have carrier info but no radio access technology, airplane mode might be on
       if let radioAccessTechnology = networkInfo.serviceCurrentRadioAccessTechnology {
-        // If the dictionary exists but is empty, airplane mode is likely on
         return radioAccessTechnology.isEmpty
       }
-      // If radioAccessTechnology is nil but we have carriers, airplane mode might be on
       return true
     }
-    
-    // For WiFi-only devices (iPad WiFi, iPod Touch), we can't reliably detect airplane mode
-    // Return the caller-provided default for non-cellular devices
+    // Airplane Mode cannot be detected reliably on devices without cellular radios.
     return defaultValue
   }
 
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-    self.eventSink = events
-    self.streamDefaultValue = self.defaultValue(from: arguments)
-    self.startMonitoring()
-    
-    // Send initial status
-    let msg = self.isAirplaneModeOn(defaultValue: self.streamDefaultValue) ? "ON" : "OFF"
+    eventSink = events
+    streamDefaultValue = defaultValue(from: arguments)
+    startMonitoring()
+
+    let msg = isAirplaneModeOn(defaultValue: streamDefaultValue) ? "ON" : "OFF"
     events(msg)
-    
     return nil
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    self.stopMonitoring()
-    self.eventSink = nil
+    stopMonitoring()
+    eventSink = nil
     return nil
   }
 
   private func startMonitoring() {
-    // Use timer-based monitoring for airplane mode changes
-    // Network framework could be used for network availability, but airplane mode
-    // specifically requires polling or listening to system notifications
+    timer?.invalidate()
     timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
       guard let self = self, let eventSink = self.eventSink else { return }
       let msg = self.isAirplaneModeOn(defaultValue: self.streamDefaultValue) ? "ON" : "OFF"
       eventSink(msg)
     }
-    
-    // Ensure timer runs even when UI is being interacted with
+
     if let timer = timer {
       RunLoop.current.add(timer, forMode: .common)
     }
@@ -94,10 +79,8 @@ public class AirplaneModeCheckerPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   private func stopMonitoring() {
     timer?.invalidate()
     timer = nil
-    pathMonitor?.cancel()
-    pathMonitor = nil
   }
-  
+
   deinit {
     stopMonitoring()
   }

--- a/ios/airplane_mode_checker/Sources/airplane_mode_checker/AirplaneModeCheckerPlugin.swift
+++ b/ios/airplane_mode_checker/Sources/airplane_mode_checker/AirplaneModeCheckerPlugin.swift
@@ -1,13 +1,10 @@
+import CoreTelephony
 import Flutter
 import UIKit
-import CoreTelephony
-import Network
 
 public class AirplaneModeCheckerPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   private var eventSink: FlutterEventSink?
   private var timer: Timer?
-  private var pathMonitor: NWPathMonitor?
-  private let monitorQueue = DispatchQueue(label: "com.u14h4i.airplane_mode_checker.monitor")
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let methodChannel = FlutterMethodChannel(name: "airplane_mode_checker", binaryMessenger: registrar.messenger())
@@ -22,68 +19,47 @@ public class AirplaneModeCheckerPlugin: NSObject, FlutterPlugin, FlutterStreamHa
     case "getPlatformVersion":
       result("iOS " + UIDevice.current.systemVersion)
     case "checkAirplaneMode":
-      self.checkAirplaneMode { (msg) in
-        result(msg)
-      }
+      result(isAirplaneModeOn() ? "ON" : "OFF")
     default:
       result(FlutterMethodNotImplemented)
     }
   }
-    
-  func checkAirplaneMode(completion: @escaping (String) -> Void) {
-    let msg = self.isAirplaneModeOn() ? "ON" : "OFF"
-    completion(msg)
-  }
 
   func isAirplaneModeOn() -> Bool {
-    // Check using CTTelephonyNetworkInfo for cellular radio
     let networkInfo = CTTelephonyNetworkInfo()
-    
-    // For devices with cellular capability
+
     if let carriers = networkInfo.serviceSubscriberCellularProviders, !carriers.isEmpty {
-      // If we have carrier info but no radio access technology, airplane mode might be on
       if let radioAccessTechnology = networkInfo.serviceCurrentRadioAccessTechnology {
-        // If the dictionary exists but is empty, airplane mode is likely on
         return radioAccessTechnology.isEmpty
       }
-      // If radioAccessTechnology is nil but we have carriers, airplane mode might be on
       return true
     }
-    
-    // For WiFi-only devices (iPad WiFi, iPod Touch), we can't reliably detect airplane mode
-    // Return false as default for non-cellular devices
+
+    // Airplane Mode cannot be detected reliably on devices without cellular radios.
     return false
   }
 
   public func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-    self.eventSink = events
-    self.startMonitoring()
-    
-    // Send initial status
-    let msg = self.isAirplaneModeOn() ? "ON" : "OFF"
-    events(msg)
-    
+    eventSink = events
+    startMonitoring()
+    events(isAirplaneModeOn() ? "ON" : "OFF")
     return nil
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
-    self.stopMonitoring()
-    self.eventSink = nil
+    stopMonitoring()
+    eventSink = nil
     return nil
   }
 
   private func startMonitoring() {
-    // Use timer-based monitoring for airplane mode changes
-    // Network framework could be used for network availability, but airplane mode
-    // specifically requires polling or listening to system notifications
+    timer?.invalidate()
     timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
-      guard let self = self, let eventSink = self.eventSink else { return }
-      let msg = self.isAirplaneModeOn() ? "ON" : "OFF"
-      eventSink(msg)
+      guard let self, let eventSink = self.eventSink else { return }
+      eventSink(self.isAirplaneModeOn() ? "ON" : "OFF")
     }
-    
-    // Ensure timer runs even when UI is being interacted with
-    if let timer = timer {
+
+    if let timer {
       RunLoop.current.add(timer, forMode: .common)
     }
   }
@@ -91,10 +67,8 @@ public class AirplaneModeCheckerPlugin: NSObject, FlutterPlugin, FlutterStreamHa
   private func stopMonitoring() {
     timer?.invalidate()
     timer = nil
-    pathMonitor?.cancel()
-    pathMonitor = nil
   }
-  
+
   deinit {
     stopMonitoring()
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: airplane_mode_checker
 description: Flutter plugin allows you to check the status of Airplane Mode on
   iOS and Android mobile.
-version: 3.2.0
+version: 3.3.0
 homepage: https://github.com/14h4i/airplane_mode_checker
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: airplane_mode_checker
 description: Flutter plugin allows you to check the status of Airplane Mode on
   iOS and Android mobile.
-version: 3.2.1
+version: 3.3.0
 homepage: https://github.com/14h4i/airplane_mode_checker
 
 environment:

--- a/test/airplane_mode_checker_method_channel_test.dart
+++ b/test/airplane_mode_checker_method_channel_test.dart
@@ -5,23 +5,37 @@ import 'package:airplane_mode_checker/airplane_mode_checker_method_channel.dart'
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  MethodChannelAirplaneModeChecker platform = MethodChannelAirplaneModeChecker();
+  MethodChannelAirplaneModeChecker platform =
+      MethodChannelAirplaneModeChecker();
   const MethodChannel channel = MethodChannel('airplane_mode_checker');
 
   setUp(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
       channel,
       (MethodCall methodCall) async {
-        return '42';
+        switch (methodCall.method) {
+          case 'getPlatformVersion':
+            return '42';
+          case 'checkAirplaneMode':
+            return 'OFF';
+          default:
+            return null;
+        }
       },
     );
   });
 
   tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
   });
 
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
+  });
+
+  test('checkAirplaneMode', () async {
+    expect(await platform.checkAirplaneMode(), 'OFF');
   });
 }

--- a/test/airplane_mode_checker_method_channel_test.dart
+++ b/test/airplane_mode_checker_method_channel_test.dart
@@ -15,9 +15,19 @@ void main() {
 
   setUp(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
-          return '42';
-        });
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        switch (methodCall.method) {
+          case 'getPlatformVersion':
+            return '42';
+          case 'checkAirplaneMode':
+            return 'OFF';
+          default:
+            return null;
+        }
+      },
+    );
   });
 
   tearDown(() {
@@ -29,6 +39,10 @@ void main() {
 
   test('getPlatformVersion', () async {
     expect(await platform.getPlatformVersion(), '42');
+  });
+
+  test('checkAirplaneMode', () async {
+    expect(await platform.checkAirplaneMode(), 'OFF');
   });
 
   test('checkAirplaneMode forwards defaultValue', () async {

--- a/test/airplane_mode_checker_test.dart
+++ b/test/airplane_mode_checker_test.dart
@@ -7,28 +7,41 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class MockAirplaneModeCheckerPlatform
     with MockPlatformInterfaceMixin
     implements AirplaneModeCheckerPlatform {
+  MockAirplaneModeCheckerPlatform({
+    this.platformVersion = '42',
+    this.airplaneMode = 'ON',
+    Stream<String>? stream,
+  }) : _stream = stream ?? Stream.value('ON');
+
+  final String? platformVersion;
+  final String? airplaneMode;
+  final Stream<String> _stream;
   String? checkDefaultValue;
   String? listenDefaultValue;
 
   @override
-  Future<String?> getPlatformVersion() => Future.value('42');
+  Future<String?> getPlatformVersion() => Future.value(platformVersion);
 
   @override
   Future<String?> checkAirplaneMode({String defaultValue = 'OFF'}) {
     checkDefaultValue = defaultValue;
-    return Future.value('ON');
+    return Future.value(airplaneMode);
   }
 
   @override
   Stream<String> listenAirplaneMode({String defaultValue = 'OFF'}) {
     listenDefaultValue = defaultValue;
-    return Stream.value('ON');
+    return _stream;
   }
 }
 
 void main() {
   final AirplaneModeCheckerPlatform initialPlatform =
       AirplaneModeCheckerPlatform.instance;
+
+  tearDown(() {
+    AirplaneModeCheckerPlatform.instance = initialPlatform;
+  });
 
   test('$MethodChannelAirplaneModeChecker is the default instance', () {
     expect(initialPlatform, isInstanceOf<MethodChannelAirplaneModeChecker>());
@@ -73,6 +86,32 @@ void main() {
     expect(fakePlatform.checkDefaultValue, 'ON');
   });
 
+  test('checkAirplaneMode maps OFF to AirplaneModeStatus.off', () async {
+    AirplaneModeChecker airplaneModeCheckerPlugin =
+        AirplaneModeChecker.instance;
+    MockAirplaneModeCheckerPlatform fakePlatform =
+        MockAirplaneModeCheckerPlatform(airplaneMode: 'OFF');
+    AirplaneModeCheckerPlatform.instance = fakePlatform;
+
+    expect(
+      await airplaneModeCheckerPlugin.checkAirplaneMode(),
+      AirplaneModeStatus.off,
+    );
+  });
+
+  test('checkAirplaneMode maps null to AirplaneModeStatus.off', () async {
+    AirplaneModeChecker airplaneModeCheckerPlugin =
+        AirplaneModeChecker.instance;
+    MockAirplaneModeCheckerPlatform fakePlatform =
+        MockAirplaneModeCheckerPlatform(airplaneMode: null);
+    AirplaneModeCheckerPlatform.instance = fakePlatform;
+
+    expect(
+      await airplaneModeCheckerPlugin.checkAirplaneMode(),
+      AirplaneModeStatus.off,
+    );
+  });
+
   test('listenAirplaneMode', () async {
     AirplaneModeChecker airplaneModeCheckerPlugin =
         AirplaneModeChecker.instance;
@@ -80,10 +119,33 @@ void main() {
         MockAirplaneModeCheckerPlatform();
     AirplaneModeCheckerPlatform.instance = fakePlatform;
 
-    airplaneModeCheckerPlugin.listenAirplaneMode().listen((event) {
-      expect(event, AirplaneModeStatus.on);
-    });
+    expect(
+      airplaneModeCheckerPlugin.listenAirplaneMode(),
+      emits(AirplaneModeStatus.on),
+    );
   });
+
+  test(
+    'listenAirplaneMode maps non-ON events to AirplaneModeStatus.off',
+    () async {
+      AirplaneModeChecker airplaneModeCheckerPlugin =
+          AirplaneModeChecker.instance;
+      MockAirplaneModeCheckerPlatform fakePlatform =
+          MockAirplaneModeCheckerPlatform(
+            stream: Stream<String>.fromIterable(['OFF', 'UNKNOWN', 'ON']),
+          );
+      AirplaneModeCheckerPlatform.instance = fakePlatform;
+
+      expect(
+        airplaneModeCheckerPlugin.listenAirplaneMode(),
+        emitsInOrder([
+          AirplaneModeStatus.off,
+          AirplaneModeStatus.off,
+          AirplaneModeStatus.on,
+        ]),
+      );
+    },
+  );
 
   test('listenAirplaneMode forwards defaultValue', () async {
     AirplaneModeChecker airplaneModeCheckerPlugin =

--- a/test/airplane_mode_checker_test.dart
+++ b/test/airplane_mode_checker_test.dart
@@ -7,16 +7,24 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 class MockAirplaneModeCheckerPlatform
     with MockPlatformInterfaceMixin
     implements AirplaneModeCheckerPlatform {
-  @override
-  Future<String?> getPlatformVersion() => Future.value('42');
+  MockAirplaneModeCheckerPlatform({
+    this.platformVersion = '42',
+    this.airplaneMode = 'ON',
+    Stream<String>? stream,
+  }) : _stream = stream ?? Stream.value('ON');
+
+  final String? platformVersion;
+  final String? airplaneMode;
+  final Stream<String> _stream;
 
   @override
-  Future<String?> checkAirplaneMode() => Future.value('ON');
+  Future<String?> getPlatformVersion() => Future.value(platformVersion);
 
   @override
-  Stream<String> listenAirplaneMode() {
-    return Stream.value('ON');
-  }
+  Future<String?> checkAirplaneMode() => Future.value(airplaneMode);
+
+  @override
+  Stream<String> listenAirplaneMode() => _stream;
 }
 
 void main() {
@@ -48,6 +56,28 @@ void main() {
         AirplaneModeStatus.on);
   });
 
+  test('checkAirplaneMode maps OFF to AirplaneModeStatus.off', () async {
+    AirplaneModeChecker airplaneModeCheckerPlugin =
+        AirplaneModeChecker.instance;
+    MockAirplaneModeCheckerPlatform fakePlatform =
+        MockAirplaneModeCheckerPlatform(airplaneMode: 'OFF');
+    AirplaneModeCheckerPlatform.instance = fakePlatform;
+
+    expect(await airplaneModeCheckerPlugin.checkAirplaneMode(),
+        AirplaneModeStatus.off);
+  });
+
+  test('checkAirplaneMode maps null to AirplaneModeStatus.off', () async {
+    AirplaneModeChecker airplaneModeCheckerPlugin =
+        AirplaneModeChecker.instance;
+    MockAirplaneModeCheckerPlatform fakePlatform =
+        MockAirplaneModeCheckerPlatform(airplaneMode: null);
+    AirplaneModeCheckerPlatform.instance = fakePlatform;
+
+    expect(await airplaneModeCheckerPlugin.checkAirplaneMode(),
+        AirplaneModeStatus.off);
+  });
+
   test('listenAirplaneMode', () async {
     AirplaneModeChecker airplaneModeCheckerPlugin =
         AirplaneModeChecker.instance;
@@ -55,8 +85,29 @@ void main() {
         MockAirplaneModeCheckerPlatform();
     AirplaneModeCheckerPlatform.instance = fakePlatform;
 
-    airplaneModeCheckerPlugin.listenAirplaneMode().listen((event) {
-      expect(event, AirplaneModeStatus.on);
-    });
+    expect(
+      airplaneModeCheckerPlugin.listenAirplaneMode(),
+      emits(AirplaneModeStatus.on),
+    );
+  });
+
+  test('listenAirplaneMode maps non-ON events to AirplaneModeStatus.off',
+      () async {
+    AirplaneModeChecker airplaneModeCheckerPlugin =
+        AirplaneModeChecker.instance;
+    MockAirplaneModeCheckerPlatform fakePlatform =
+        MockAirplaneModeCheckerPlatform(
+      stream: Stream<String>.fromIterable(['OFF', 'UNKNOWN', 'ON']),
+    );
+    AirplaneModeCheckerPlatform.instance = fakePlatform;
+
+    expect(
+      airplaneModeCheckerPlugin.listenAirplaneMode(),
+      emitsInOrder([
+        AirplaneModeStatus.off,
+        AirplaneModeStatus.off,
+        AirplaneModeStatus.on,
+      ]),
+    );
   });
 }


### PR DESCRIPTION
## Summary

Add Swift Package Manager support for the iOS plugin and roll the related cleanup into the upcoming `3.3.0` release.

## What changed

- added SwiftPM support for iOS
- migrated iOS source files to the SwiftPM layout
- raised the minimum iOS version to `13.0`
- updated README and changelog
- fixed the stale example widget test
- expanded Dart test coverage
- tightened Android event stream cleanup

## Validation

- `flutter test`
- `flutter test` in `example/`
- `flutter analyze`
- `flutter analyze` in `example/`
